### PR TITLE
release 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ client.getPublicChannelStream(List.of("orderbook.50.BTCUSDT","orderbook.1.ETHUSD
 ### Websocket private channel
 - Order Subscribe
 ```java
-var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
 // Position
 // client.getOrderBookStream(List.of("position.linear"), BybitApiConfig.V5_PRIVATE);
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dive into a plethora of functionalities:
 
 bybit-java-api provides an official, robust, and high-performance Java connector to Bybit's trading APIs. 
 
-Initially conceptualized by esteemed Java developer Victor, this module is now maintained by Bybit's in-house Java experts. 
+Initially conceptualized by Java developer Victor, this module is now maintained by Bybit's in-house Java experts. 
 
 Your contributions are most welcome!
 
@@ -35,175 +35,188 @@ Ensure you have Java 11 or higher. You can include bybit-java-api in your projec
 
 Maven Example
 ```java
-    <!-- Maven -->
-    <dependency>
-        <groupId>io.github.wuhewuhe</groupId>
-        <artifactId>bybit-java-api</artifactId>
-        <version>1.1.0</version>
-    </dependency>
+<!-- Maven -->
+<dependency>
+    <groupId>io.github.wuhewuhe</groupId>
+    <artifactId>bybit-java-api</artifactId>
+    <version>1.1.1</version>
+</dependency>
 ```
 Gradle Example
 ```java
-    implementation group: 'io.github.wuhewuhe', name: 'bybit-java-api', version: '1.1.0'
+implementation group: 'io.github.wuhewuhe', name: 'bybit-java-api', version: '1.1.1'
 ```
-Furthermore build tool, please check [sonar type central repository](https://central.sonatype.com/artifact/io.github.wuhewuhe/bybit-java-api/1.1.0)
+Furthermore build tool, please check [sonar type central repository](https://central.sonatype.com/artifact/io.github.wuhewuhe/bybit-java-api/1.1.1)
 ## Usage
 Note: Replace placeholders (like YOUR_API_KEY, links, or other details) with the actual information. You can also customize this template to better fit the actual state and details of your Java API.
-### Http Async Examples
-- Create Factory 
+### HttP Client Factory & Websocket Client
+#### Client Factory Option
 ```java
-        // Client Factory in Mainnet with API key and Secret
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET");
-        // Client Factory in Testnet, with API key and Secret
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN);
-        // Client Factory in Mainnet without API key and Secret
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance()
-        // Client Factory in Testnet without API key and Secret
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance(true)
+private final String apiKey;
+private final String secret;
+private final String baseUrl;
+private final Boolean debugMode;
+private final String logOption;
+private final Long recvWindow;
 ```
 
-- Place Single Order
+### Http Async Examples
+- Place Single Order By Object
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN);
-        BybitApiAsyncTradeRestClient client = factory.newAsyncTradeRestClient();
-        // Place an order
-        var newOrderRequest = TradeOrderRequest.builder().category(CategoryType.LINEAR).symbol("XRPUSDT")
-                .side(Side.BUY).orderType(TradeOrderType.MARKET).qty("10").timeInForce(TimeInForce.IMMEDIATE_OR_CANCEL)
-                .positionIdx(PositionIdx.ONE_WAY_MODE).build();
-        client.createOrder(newOrderRequest, System.out::println);
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN, true).newAsyncTradeRestClient();
+        Map<String, Object> order =Map.of(
+        "category", "option",
+        "symbol", "BTC-29DEC23-10000-P",
+        "side", "Buy",
+        "orderType", "Limit",
+        "orderIv", "0.1",
+        "qty", "0.1",
+        "price", "5"
+        );
+        client.createOrder(order, System.out::println);
+```
+
+- Place Single Order By Map
+```java
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN, true).newAsyncTradeRestClient();
+var newOrderRequest = TradeOrderRequest.builder().category(CategoryType.LINEAR).symbol("XRPUSDT")
+.side(Side.BUY).orderType(TradeOrderType.MARKET).qty("10").timeInForce(TimeInForce.GOOD_TILL_CANCEL)
+.positionIdx(PositionIdx.ONE_WAY_MODE).build();
+client.createOrder(newOrderRequest, System.out::println);
 ```
 
 - Place Batch Order
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET",true);
-        BybitApiAsyncTradeRestClient client = factory.newAsyncTradeRestClient();
-        // Create a batch order
-        var orderRequests = Arrays.asList(TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
-                .price("5").orderIv("0.1").timeInForce(TimeInForce.GOOD_TILL_CANCEL).orderLinkId("9b381bb1-401").mmp(false).reduceOnly(false).build(),
-                TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
-                .price("5").orderIv("0.1").timeInForce(TimeInForce.GOOD_TILL_CANCEL).orderLinkId("82ee86dd-001").mmp(false).reduceOnly(false).build());
-                var createBatchOrders = BatchOrderRequest.builder().category(CategoryType.OPTION).request(orderRequests).build();
-        client.createBatchOrder(createBatchOrders, System.out::println);
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newAsyncTradeRestClient();
+var orderRequests = Arrays.asList(TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
+.price("5").orderIv("0.1").timeInForce(TimeInForce.GOOD_TILL_CANCEL).orderLinkId("9b381bb1-401").mmp(false).reduceOnly(false).build(),
+TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
+.price("5").orderIv("0.1").timeInForce(TimeInForce.GOOD_TILL_CANCEL).orderLinkId("82ee86dd-001").mmp(false).reduceOnly(false).build());
+var createBatchOrders = BatchOrderRequest.builder().category(CategoryType.OPTION).request(orderRequests).build();
+client.createBatchOrder(createBatchOrders, System.out::println);
 ```
 - Position Info
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET",true);
-        var client = factory.newAsyncPositionRestClient();
-        // Get Position Info
-        var positionListRequest = PositionDataRequest.builder().category(CategoryType.LINEAR).symbol("BTCUSDT").build();
-        client.getPositionInfo(positionListRequest, System.out::println);
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newAsyncPositionRestClient();
+var positionListRequest = PositionDataRequest.builder().category(CategoryType.LINEAR).symbol("BTCUSDT").build();
+client.getPositionInfo(positionListRequest, System.out::println);
 ```
 - Asset Info
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET",true);
-        var client = factory.newAsyncAssetRestClient();
-        // Get Coin Exchange Records
-        var coinExchangeRecordsRequest = AssetDataRequest.builder().build();
-        client.getAssetCoinExchangeRecords(coinExchangeRecordsRequest, System.out::println);
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newAsyncAssetRestClient();
+var coinExchangeRecordsRequest = AssetDataRequest.builder().build();
+client.getAssetCoinExchangeRecords(coinExchangeRecordsRequest, System.out::println);
 ```
 ### Http Sync Examples
+- Amend Order
+```java
+var amendOrderRequest = TradeOrderRequest.builder().orderId("1523347543495541248").category(CategoryType.LINEAR).symbol("XRPUSDT")
+        .price("0.5")  // setting a new price, for example
+        .qty("15")  // and a new quantity
+        .build();
+var amendedOrder = client.amendOrder(amendOrderRequest);
+System.out.println(amendedOrder);
+```
 - Place Batch Order
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN);
-        BybitApiTradeRestClient client = factory.newTradeRestClient();
-        // Create a batch order
-        var orderRequests = Arrays.asList(TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
-                        .price("5").orderIv("0.1").timeInForce(TimeInForce.GoodTillCancel).orderLinkId("9b381bb1-401").mmp(false).reduceOnly(false).build(),
-                TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")
-                        .price("5").orderIv("0.1").timeInForce(TimeInForce.GoodTillCancel).orderLinkId("82ee86dd-001").mmp(false).reduceOnly(false).build());
-        var createBatchOrders = BatchOrderRequest.builder().category(CategoryType.OPTION).request(orderRequests).build();
-        var createBatchRequestResponse = client.createBatchOrder(createBatchOrders);
-        System.out.println(createBatchRequestResponse);
-
-        // Create a batch order by map
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("category", "option");
-        List<Map<String, Object>> orders = new ArrayList<>();
-        List<Integer> prices = Arrays.asList(15000, 15500, 16000, 16500, 16600);
-        for (Integer price : prices) {
-            Map<String, Object> order = new HashMap<>();
-            order.put("symbol", "BTC-30JUN23-20000-C");
-            order.put("side", "Buy");
-            order.put("orderType", "Limit");
-            order.put("qty", "0.1");
-            order.put("price", price.toString());
-            orders.add(order);
-        }
-        payload.put("request", orders);
-        var createBatchResponse = client.createBathOrder(payload);
-        System.out.println(createBatchResponse);
-        
-        var batchOrderRequest = client.createBathOrder(jsonRequest);
-        System.out.println(batchOrderRequest);
+String jsonRequest = """
+{
+  "category":"option", 
+  "request": [ 
+  {  
+  "category":"option", 
+  "symbol":"BTC-10FEB23-24000-C", 
+  "orderType":"Limit", 
+  "side":"Buy",   
+  "qty":"0.1", 
+  "price":"5", 
+  "orderIv":"0.1", 
+  "timeInForce":"GTC", 
+  "orderLinkId":"9b381bb1-401", 
+  "mmp":false, 
+  "reduceOnly":false  
+  },
+  {  
+  "category":"option", 
+  "symbol":"BTC-10FEB23-24000-C", 
+  "orderType":"Limit", 
+  "side":"Buy",   
+  "qty":"0.1", 
+  "price":"5", 
+  "orderIv":"0.1", 
+  "timeInForce":"GTC", 
+  "orderLinkId":"82ee86dd-001", 
+  "mmp":false, 
+  "reduceOnly":false  
+  } 
+ ]
+}
+""";
+var batchOrderRequest = client.createBathOrder(jsonRequest);
+System.out.println(batchOrderRequest);
 ```
 
 - Market Data Info 
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance(true);
-        var client = factory.newMarketDataRestClient();
-        var marketKLineRequest = MarketDataRequest.builder().category(CategoryType.LINEAR).symbol("BTCUSDT").marketInterval(MarketInterval.WEEKLY).build();
-        // Weekly market Kline
-        var marketKlineResult = client.getMarketLinesData(marketKLineRequest);
-        System.out.println(marketKlineResult);
-```
-- Account Data Info
-```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET",true);
-        var client = factory.newAccountRestClient();
-        // Get wallet balance
-        var walletBalanceRequest = AccountDataRequest.builder().accountType(AccountType.UNIFIED).build();
-        var walletBalanceData = client.getWalletBalance(walletBalanceRequest);
-        System.out.println(walletBalanceData);
+var client = BybitApiClientFactory.newInstance(BybitApiConfig.TESTNET_DOMAIN,true).newMarketDataRestClient();
+var marketKLineRequest = MarketDataRequest.builder().category(CategoryType.LINEAR).symbol("BTCUSDT").marketInterval(MarketInterval.WEEKLY).build();
+// Weekly market Kline
+var marketKlineResult = client.getMarketLinesData(marketKLineRequest);
+System.out.println(marketKlineResult);
+
+// Weekly market price Kline for a symbol
+var marketPriceKlineResult = client.getMarketPriceLinesData(marketKLineRequest);
+System.out.println(marketPriceKlineResult);
+
+// Weekly index price Kline for a symbol
+var indexPriceKlineResult = client.getIndexPriceLinesData(marketKLineRequest);
+System.out.println(indexPriceKlineResult);
+
+// Weekly premium index price Kline for a symbol
+var indexPremiumPriceKlineResult = client.getPremiumIndexPriceLinesData(marketKLineRequest);
+System.out.println(indexPremiumPriceKlineResult);
+
+// Get server time
+var serverTime = client.getServerTime();
+System.out.println(serverTime);
 ```
 
 - User Management
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET",true);
-        var client = factory.newUserRestClient();
-        // create a new sub user
-        var subUserRequest = UserDataRequest.builder().username("VictorWuTest3")
-        .password("Password123")
-        .memberType(MemberType.NORMAL_SUB_ACCOUNT)
-        .note("Some note")
-        .switchOption(SwitchOption.TURN_OFF)
-        .isUta(IsUta.CLASSIC_ACCOUNT)
-        .build();
-        var subUser = client.createSubMember(subUserRequest);
-        System.out.println(subUser);
+var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newUserRestClient();
+var subUserRequest = UserDataRequest.builder().username("VictorWuTest3").password("Password123").memberType(MemberType.NORMAL_SUB_ACCOUNT).note("Some note").switchOption(SwitchOption.TURN_OFF).isUta(IsUta.CLASSIC_ACCOUNT).build();
+var subUser = client.createSubMember(subUserRequest);
+System.out.println(subUser);
+```
+
+#### Websocket Client
+```java
+private final Integer pingInterval;
+private final WebsocketMessageHandler messageHandler;
+private final String maxAliveTime; // Only valid for private channel
 ```
 
 ### Websocket public channel
-- Create Websocket Client
-```java
-        // new websocket client in debug mode
-        var client = factory.newWebsocketClient(true);
-        // new websocket client with message handler
-        var client = factory.newWebsocketClient((message) -> System.out.println("Handle message :" + message));
-        // new websocket client with message handler and debug mode
-        var client = factory.newWebsocketClient((message) -> System.out.println("Handle message :" + message), true);
-        // new websocket client without message handler and debug mode
-        var client = factory.newWebsocketClient();
-```
 - Order book Subscribe
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance();
-        var client = factory.newWebsocketClient((message) -> System.out.println("Handle message :" + message), true);
+var client = BybitApiClientFactory.newInstance(BybitApiConfig.STREAM_TESTNET_DOMAIN, true, "okhttp3").newWebsocketClient(20);
 
-        // Orderbook
-        client.getPublicChannelStream(List.of("orderbook.50.BTCUSDT"), BybitApiConfig.V5_PUBLIC_LINEAR);
-        
-        // Subscribe Orderbook more than one args
-        client.getPublicChannelStream(List.of("orderbook.50.BTCUSDT","orderbook.1.ETHUSDT"), BybitApiConfig.V5_PUBLIC_LINEAR);
+// Orderbook
+client.getPublicChannelStream(List.of("orderbook.50.BTCUSDT"), BybitApiConfig.V5_PUBLIC_LINEAR);
+
+// Subscribe Orderbook more than one args
+client.getPublicChannelStream(List.of("orderbook.50.BTCUSDT","orderbook.1.ETHUSDT"), BybitApiConfig.V5_PUBLIC_LINEAR);
 ```
 
 ### Websocket private channel
 - Order Subscribe
 ```java
-        BybitApiClientFactory factory = BybitApiClientFactory.newInstance("YOUR_API_KEY","YOUR_API_SECRET",true);
-        var client = factory.newWebsocketClient((message) -> System.out.println("Handle message :" + message), true);
+var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
+// Position
+// client.getOrderBookStream(List.of("position.linear"), BybitApiConfig.V5_PRIVATE);
 
-        // Order
-        client.getPrivateChannelStream(List.of("order"), BybitApiConfig.V5_PRIVATE);
+// Order
+client.getPrivateChannelStream(List.of("order"), BybitApiConfig.V5_PRIVATE);
 ```
 ## Contact
 For support, join our Bybit API community on [Telegram](https://t.me/Bybitapi).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - [About](#about)
 - [Development](#development)
 - [Installation](#installation)
+- [Release Notes](#release-notes)
 - [Usage](#usage)
 - [Contact](#contact)
 - [Contributors](#contributors)
@@ -47,6 +48,32 @@ Gradle Example
 implementation group: 'io.github.wuhewuhe', name: 'bybit-java-api', version: '1.1.1'
 ```
 Furthermore build tool, please check [sonar type central repository](https://central.sonatype.com/artifact/io.github.wuhewuhe/bybit-java-api/1.1.1)
+
+## Release-Notes
+### HTTP Sync & Async Request
+- Receive Window Parameter: Added by default (5 seconds).
+- Debug Mode Parameter: Added by default (false) to print request and response headers.
+- Base URL Setting: Allows setting to testnet or mainnet.
+- Log Option Interceptor Parameter: Currently supports SLF4J and OkHttp3; planning to support customized messaging in the next version.
+- Trade API: For create/amend/cancel single & batch orders, now supports dedicated class, map, and JSON.
+- Asset API: Deposit and withdrawal operations will automatically generate a transfer ID.
+
+### WebSocket
+- Ping Pong Interval Parameter: Added by default (20 seconds).
+- Max Alive Time Parameter: Only supports private channel, ranging from 30s to 600s (also supports minutes).
+- Log Option Interceptor for WebSocket: Currently supports SLF4J and OkHttp3; planning to support customized messaging in the next version.
+
+### Improvements
+- Class Mapping for POST Requests: Each POST request will have a class mapped and converted to JSON for the request body.
+- Enhanced Unit Tests: Added more tests for serialization and deserialization of data.
+- Performance Tests for WebSocket: Added tests for maximum argument limits.
+- POST Request Handling: Parameters not supported in query string will be reset to the body.
+- Security Enhancements: Secure check for signed requests implemented.
+### Change Log
+- CategoryType: Renamed from ProductType.
+- Deprecated useTestnet: This function is now deprecated.
+- Serialization Optimization: No reserialization of data before sending POST requests, using conversion instead.
+
 ## Usage
 Note: Replace placeholders (like YOUR_API_KEY, links, or other details) with the actual information. You can also customize this template to better fit the actual state and details of your Java API.
 ### HttP Client Factory & Websocket Client
@@ -193,7 +220,7 @@ System.out.println(subUser);
 ```java
 private final Integer pingInterval;
 private final WebsocketMessageHandler messageHandler;
-private final String maxAliveTime; // Only valid for private channel
+private final String maxAliveTime; // Only valid for private channel, timeunit in seconds or minutes
 ```
 
 ### Websocket public channel

--- a/src/main/java/com/bybit/api/client/config/BybitApiConfig.java
+++ b/src/main/java/com/bybit/api/client/config/BybitApiConfig.java
@@ -1,7 +1,5 @@
 package com.bybit.api.client.config;
 
-import lombok.Getter;
-
 /**
  * Configuration used for Bybit operations.
  */
@@ -31,7 +29,6 @@ public class BybitApiConfig {
      */
     @Deprecated
     public static boolean useTestnet;
-    public static boolean useSlf4j = false;
 
     // V5
     public static final String V5_PUBLIC_SPOT = "/v5/public/spot";

--- a/src/main/java/com/bybit/api/client/constant/BybitApiConstants.java
+++ b/src/main/java/com/bybit/api/client/constant/BybitApiConstants.java
@@ -37,7 +37,14 @@ public class BybitApiConstants {
      * Default receiving window.
      */
     public static final long DEFAULT_RECEIVING_WINDOW = 5000;
-
+    /**
+     * Default Ping Pong Heart Beat Request Interval
+     */
+    public static final int DEFAULT_PING_INTERVAL = 15;
+    /**
+     * Default Maximum Alive Time
+     */
+    public static final String DEFAULT_MAX_ALIVE_TIME = "-1";
     /**
      * Default content type.
      */

--- a/src/main/java/com/bybit/api/client/constant/BybitApiConstants.java
+++ b/src/main/java/com/bybit/api/client/constant/BybitApiConstants.java
@@ -40,7 +40,7 @@ public class BybitApiConstants {
     /**
      * Default Ping Pong Heart Beat Request Interval
      */
-    public static final int DEFAULT_PING_INTERVAL = 15;
+    public static final int DEFAULT_PING_INTERVAL = 20;
     /**
      * Default Maximum Alive Time
      */

--- a/src/main/java/com/bybit/api/client/constant/Util.java
+++ b/src/main/java/com/bybit/api/client/constant/Util.java
@@ -15,25 +15,8 @@ public final class Util {
         return Instant.now().toEpochMilli();
     }
 
-    /**
-     * List of fiat currencies.
-     */
-    public static final List<String> FIAT_CURRENCY = List.of("USDT", "BUSD", "PAX", "TUSD", "USDC", "NGN", "RUB", "USDS", "TRY");
-
-    public static final String BTC_TICKER = "BTC";
-
     private Util() {
 
-    }
-
-    /**
-     * Check if the ticker is fiat currency.
-     */
-    public static boolean isFiatCurrency(String symbol) {
-        for (String fiat : FIAT_CURRENCY) {
-            if (symbol.equals(fiat)) return true;
-        }
-        return false;
     }
 
     public static Map<String, Object> convertQueryToMap(String query) {

--- a/src/main/java/com/bybit/api/client/domain/asset/AssetDataRequest.java
+++ b/src/main/java/com/bybit/api/client/domain/asset/AssetDataRequest.java
@@ -2,7 +2,6 @@ package com.bybit.api.client.domain.asset;
 
 import com.bybit.api.client.domain.CategoryType;
 import com.bybit.api.client.domain.account.AccountType;
-import com.bybit.api.client.domain.asset.request.WithTransferSafeAmount;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/bybit/api/client/domain/asset/WithTransferSafeAmount.java
+++ b/src/main/java/com/bybit/api/client/domain/asset/WithTransferSafeAmount.java
@@ -1,4 +1,4 @@
-package com.bybit.api.client.domain.asset.request;
+package com.bybit.api.client.domain.asset;
 
 import lombok.Getter;
 

--- a/src/main/java/com/bybit/api/client/domain/trade/TimeInForce.java
+++ b/src/main/java/com/bybit/api/client/domain/trade/TimeInForce.java
@@ -4,14 +4,17 @@ import lombok.Getter;
 
 @Getter
 public enum TimeInForce {
-    GOOD_TILL_CANCEL("GTC"),
-    IMMEDIATE_OR_CANCEL("IOC"),
-    FILL_OR_KILL("FOK"),
-    POST_ONLY("PostOnly");
+    GOOD_TILL_CANCEL("GoodTillCancel"),
+    IMMEDIATE_OR_CANCEL("ImmediateOrCancel"),
+    FILL_OR_KILL("FillOrKill"),
+    POST_ONLY("PostOnly"),
+    GTC("GTC"),
+    IOC("IOC"),
+    FOK("FOK");
 
-    private final String description;
+    private final String[] description;
 
-    TimeInForce(String description) {
+    TimeInForce(String ... description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/bybit/api/client/impl/BybitApBrokerRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApBrokerRestClientImpl.java
@@ -10,8 +10,8 @@ import static com.bybit.api.client.service.BybitApiServiceGenerator.executeSync;
 public class BybitApBrokerRestClientImpl implements BybitApiBrokerRestClient {
     private final BybitApiService bybitApiService;
 
-    public BybitApBrokerRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApBrokerRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
     // Broker
     @Override

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAccountRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAccountRestClientImpl.java
@@ -12,8 +12,8 @@ public class BybitApiAccountRestClientImpl implements BybitApiAccountRestClient 
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAccountRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAccountRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
     // Account endpoints
     @Override

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAssetRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAssetRestClientImpl.java
@@ -16,8 +16,8 @@ public class BybitApiAssetRestClientImpl implements BybitApiAssetRestClient {
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAssetRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAssetRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Asset Endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncAccountRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncAccountRestClientImpl.java
@@ -11,8 +11,9 @@ import static com.bybit.api.client.service.BybitApiServiceGenerator.createServic
 public class BybitApiAsyncAccountRestClientImpl implements BybitApiAsyncAccountRestClient {
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
-    public BybitApiAsyncAccountRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+
+    public BybitApiAsyncAccountRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Account Endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncAssetRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncAssetRestClientImpl.java
@@ -18,8 +18,8 @@ public class BybitApiAsyncAssetRestClientImpl implements BybitApiAsyncAssetRestC
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAsyncAssetRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAsyncAssetRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Asset endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncBrokerRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncBrokerRestClientImpl.java
@@ -4,16 +4,13 @@ import com.bybit.api.client.restApi.BybitApiAsyncBrokerRestClient;
 import com.bybit.api.client.restApi.BybitApiCallback;
 import com.bybit.api.client.restApi.BybitApiService;
 import com.bybit.api.client.domain.broker.BrokerDataRequest;
-import com.bybit.api.client.service.BybitJsonConverter;
 
 import static com.bybit.api.client.service.BybitApiServiceGenerator.createService;
 
 public class BybitApiAsyncBrokerRestClientImpl implements BybitApiAsyncBrokerRestClient {
     private final BybitApiService bybitApiService;
-    private final BybitJsonConverter converter = new BybitJsonConverter();
-
-    public BybitApiAsyncBrokerRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, baseUrl, debugMode);
+    public BybitApiAsyncBrokerRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     @Override

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncLendingRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncLendingRestClientImpl.java
@@ -12,8 +12,8 @@ public class BybitApiAsyncLendingRestClientImpl implements BybitApiAsyncLendingR
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAsyncLendingRestClientImpl(String apiKey, String apiSecret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, apiSecret, baseUrl, debugMode);
+    public BybitApiAsyncLendingRestClientImpl(String apiKey, String apiSecret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, apiSecret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Institution Lending

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncPositionRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncPositionRestClientImpl.java
@@ -16,8 +16,8 @@ public class BybitApiAsyncPositionRestClientImpl implements BybitApiAsyncPositio
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAsyncPositionRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAsyncPositionRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Position Data

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncSpotMarginRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncSpotMarginRestClientImpl.java
@@ -16,8 +16,8 @@ public class BybitApiAsyncSpotMarginRestClientImpl implements BybitApiAsyncSpotM
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAsyncSpotMarginRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAsyncSpotMarginRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Spots

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncUserRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncUserRestClientImpl.java
@@ -19,8 +19,8 @@ public class BybitApiAsyncUserRestClientImpl implements BybitApiAsyncUserRestCli
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiAsyncUserRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiAsyncUserRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // pre upgrade endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiLendingRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiLendingRestClientImpl.java
@@ -12,8 +12,8 @@ public class BybitApiLendingRestClientImpl implements BybitApiLendingRestClient 
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiLendingRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiLendingRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
     // Institution endpoints
     @Override

--- a/src/main/java/com/bybit/api/client/impl/BybitApiMarketAsyncRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiMarketAsyncRestClientImpl.java
@@ -5,15 +5,14 @@ import com.bybit.api.client.restApi.BybitApiCallback;
 import com.bybit.api.client.restApi.BybitApiService;
 import com.bybit.api.client.domain.announcement.request.AnnouncementInfoRequest;
 import com.bybit.api.client.domain.market.request.MarketDataRequest;
-import com.bybit.api.client.service.BybitJsonConverter;
 
 import static com.bybit.api.client.service.BybitApiServiceGenerator.createService;
 
 public class BybitApiMarketAsyncRestClientImpl implements BybitApiAsyncMarketDataRestClient {
     private final BybitApiService bybitApiService;
 
-    public BybitApiMarketAsyncRestClientImpl(String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, baseUrl, debugMode);
+    public BybitApiMarketAsyncRestClientImpl(String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, baseUrl, debugMode, recvWindow, logOption);
     }
     // Market Data endpoints
 

--- a/src/main/java/com/bybit/api/client/impl/BybitApiMarketRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiMarketRestClientImpl.java
@@ -13,8 +13,8 @@ import static com.bybit.api.client.service.BybitApiServiceGenerator.executeSync;
 public class BybitApiMarketRestClientImpl implements BybitApiMarketRestClient {
     private final BybitApiService bybitApiService;
 
-    public BybitApiMarketRestClientImpl(String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, baseUrl, debugMode);
+    public BybitApiMarketRestClientImpl(String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Market Data endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiPositionRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiPositionRestClientImpl.java
@@ -12,8 +12,8 @@ public class BybitApiPositionRestClientImpl implements BybitApiPositionRestClien
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiPositionRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiPositionRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Position endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiSpotMarginRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiSpotMarginRestClientImpl.java
@@ -15,8 +15,8 @@ public class BybitApiSpotMarginRestClientImpl implements BybitApiSpotMarginRestC
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiSpotMarginRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiSpotMarginRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Spots

--- a/src/main/java/com/bybit/api/client/impl/BybitApiTradeAsyncRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiTradeAsyncRestClientImpl.java
@@ -16,8 +16,8 @@ public class BybitApiTradeAsyncRestClientImpl implements BybitApiAsyncTradeRestC
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiTradeAsyncRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiTradeAsyncRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     @Override

--- a/src/main/java/com/bybit/api/client/impl/BybitApiTradeRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiTradeRestClientImpl.java
@@ -16,8 +16,8 @@ public class BybitApiTradeRestClientImpl implements BybitApiTradeRestClient {
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiTradeRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiTradeRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // Trade Data endpoints

--- a/src/main/java/com/bybit/api/client/impl/BybitApiUserRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiUserRestClientImpl.java
@@ -19,8 +19,8 @@ public class BybitApiUserRestClientImpl implements BybitApiUserRestClient {
     private final BybitApiService bybitApiService;
     private final BybitJsonConverter converter = new BybitJsonConverter();
 
-    public BybitApiUserRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode);
+    public BybitApiUserRestClientImpl(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        bybitApiService = createService(BybitApiService.class, apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     // User endpoints

--- a/src/main/java/com/bybit/api/client/log/LogOption.java
+++ b/src/main/java/com/bybit/api/client/log/LogOption.java
@@ -1,0 +1,17 @@
+package com.bybit.api.client.log;
+
+import lombok.Getter;
+
+@Getter
+public enum LogOption {
+    SLF4J("slf4j"),
+    OKHTTP3("okhttp3"),
+    UNKNOWN("unknown"),
+    CUSTOMIZE("customize");
+
+    private final String logOptionType;
+
+    LogOption(String logOptionType) {
+        this.logOptionType = logOptionType;
+    }
+}

--- a/src/main/java/com/bybit/api/client/log/Slf4jLoggingInterceptor.java
+++ b/src/main/java/com/bybit/api/client/log/Slf4jLoggingInterceptor.java
@@ -41,11 +41,11 @@ public class Slf4jLoggingInterceptor implements Interceptor {
     }
 
 
-    public static void HandleLoggingInterceptor(OkHttpClient.Builder clientBuilder) {
+    public static void HandleLoggingInterceptor(OkHttpClient.Builder clientBuilder, String logOption) {
         LOGGER.info("Debug Mode Activated, Trace Request in body level");
-        if(BybitApiConfig.useSlf4j)
+        if(LogOption.SLF4J.getLogOptionType().equals(logOption.trim().toLowerCase()))
             clientBuilder.addInterceptor(new Slf4jLoggingInterceptor());
-        else{
+        else if(LogOption.OKHTTP3.getLogOptionType().equals(logOption.trim().toLowerCase())){
             HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(LOGGER::info);
             loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
             clientBuilder.addInterceptor(loggingInterceptor);

--- a/src/main/java/com/bybit/api/client/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/bybit/api/client/security/AuthenticationInterceptor.java
@@ -21,9 +21,12 @@ public class AuthenticationInterceptor implements Interceptor {
 
     private final String secret;
 
-    public AuthenticationInterceptor(String apiKey, String secret) {
+    private final Long recvWindow;
+
+    public AuthenticationInterceptor(String apiKey, String secret, Long recvWindow) {
         this.apiKey = apiKey;
         this.secret = secret;
+        this.recvWindow = recvWindow;
     }
 
     @NotNull
@@ -50,11 +53,11 @@ public class AuthenticationInterceptor implements Interceptor {
 
         if (isSignatureRequired) {
             long timestamp = Util.generateTimestamp();
-            String signature = sign(apiKey, secret, StringUtils.isEmpty(payload) ? ""  : payload, timestamp, BybitApiConstants.DEFAULT_RECEIVING_WINDOW);
+            String signature = sign(apiKey, secret, StringUtils.isEmpty(payload) ? ""  : payload, timestamp, recvWindow);
             newRequestBuilder.addHeader(BybitApiConstants.API_KEY_HEADER, apiKey);
             newRequestBuilder.addHeader(BybitApiConstants.SIGN_HEADER, signature);
             newRequestBuilder.addHeader(BybitApiConstants.TIMESTAMP_HEADER, String.valueOf(timestamp));
-            newRequestBuilder.addHeader(BybitApiConstants.RECV_WINDOW_HEADER, String.valueOf(BybitApiConstants.DEFAULT_RECEIVING_WINDOW));
+            newRequestBuilder.addHeader(BybitApiConstants.RECV_WINDOW_HEADER, String.valueOf(recvWindow));
             newRequestBuilder.addHeader(BybitApiConstants.API_CONTENT_TYPE, BybitApiConstants.DEFAULT_CONTENT_TYPE);
         }
         Request newRequest = newRequestBuilder.build();

--- a/src/main/java/com/bybit/api/client/security/HmacSHA256Signer.java
+++ b/src/main/java/com/bybit/api/client/security/HmacSHA256Signer.java
@@ -1,18 +1,12 @@
 package com.bybit.api.client.security;
 
-import com.alibaba.fastjson.JSON;
 import com.bybit.api.client.exception.BybitApiException;
-import okhttp3.WebSocket;
 import org.apache.commons.codec.binary.Hex;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Utility class to sign messages using HMAC-SHA256.
@@ -35,7 +29,7 @@ public class HmacSHA256Signer {
         }
 
         String message = timestamp + apiKey + recvWindow + payload;
-        Mac sha256_HMAC = null;
+        Mac sha256_HMAC;
         try {
             sha256_HMAC = Mac.getInstance("HmacSHA256");
             SecretKeySpec secretKeySpec = new SecretKeySpec(apiSecret.getBytes(), "HmacSHA256");
@@ -44,22 +38,6 @@ public class HmacSHA256Signer {
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * To convert bytes to hex
-     *
-     * @param hash
-     * @return hex string
-     */
-    private static String bytesToHex(byte[] hash) {
-        StringBuilder hexString = new StringBuilder();
-        for (byte b : hash) {
-            String hex = Integer.toHexString(0xff & b);
-            if (hex.length() == 1) hexString.append('0');
-            hexString.append(hex);
-        }
-        return hexString.toString();
     }
 
     public static String auth(String data, String apiSecret) {

--- a/src/main/java/com/bybit/api/client/service/BybitApiClientFactory.java
+++ b/src/main/java/com/bybit/api/client/service/BybitApiClientFactory.java
@@ -1,12 +1,15 @@
 package com.bybit.api.client.service;
 
 
-import com.bybit.api.client.config.BybitApiConfig;
 import com.bybit.api.client.impl.*;
+import com.bybit.api.client.log.LogOption;
 import com.bybit.api.client.restApi.*;
 import com.bybit.api.client.websocket.WebsocketClient;
 import com.bybit.api.client.websocket.WebsocketClientImpl;
 import com.bybit.api.client.websocket.WebsocketMessageHandler;
+
+import static com.bybit.api.client.config.BybitApiConfig.MAINNET_DOMAIN;
+import static com.bybit.api.client.constant.BybitApiConstants.*;
 
 /**
  * A factory for creating BybitApi client objects.
@@ -31,7 +34,17 @@ public class BybitApiClientFactory {
     /**
      * DebugMode to print request and response header
      */
-    private final boolean debugMode;
+    private final Boolean debugMode;
+
+    /**
+     * DebugMode log option to print request and response header
+     */
+    private final String logOption;
+
+    /**
+     * recvWindow to print request and response header
+     */
+    private final Long recvWindow;
 
     /**
      * Instantiates a new Bybit api client factory.
@@ -41,32 +54,13 @@ public class BybitApiClientFactory {
      * @param baseUrl   base url
      * @param debugMode debugMode
      */
-    private BybitApiClientFactory(String apiKey, String secret, String baseUrl, boolean debugMode) {
+    private BybitApiClientFactory(String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
         this.apiKey = apiKey;
         this.secret = secret;
         this.baseUrl = baseUrl;
         this.debugMode = debugMode;
-    }
-
-    private BybitApiClientFactory(String apiKey, String secret, boolean debugMode) {
-        this.apiKey = apiKey;
-        this.secret = secret;
-        this.baseUrl = BybitApiConfig.MAINNET_DOMAIN;
-        this.debugMode = debugMode;
-    }
-
-    private BybitApiClientFactory(String apiKey, String secret, String baseUrl) {
-        this.apiKey = apiKey;
-        this.secret = secret;
-        this.baseUrl = baseUrl;
-        this.debugMode = false;
-    }
-
-    private BybitApiClientFactory(String apiKey, String secret) {
-        this.apiKey = apiKey;
-        this.secret = secret;
-        this.baseUrl = BybitApiConfig.MAINNET_DOMAIN;
-        this.debugMode = false;
+        this.recvWindow = recvWindow;
+        this.logOption = logOption;
     }
 
     /**
@@ -77,20 +71,24 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory
      */
     public static BybitApiClientFactory newInstance(String apiKey, String secret) {
-        return new BybitApiClientFactory(apiKey, secret);
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, false, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
     }
 
 
     /**
      * New instance of Api Mainnet Client with url
      *
-     * @param apiKey    the API key
-     * @param secret    the Secret
-     * @param baseUrl    the baseUrl
+     * @param apiKey  the API key
+     * @param secret  the Secret
+     * @param baseUrl the baseUrl
      * @return the Bybit api client factory.
      */
     public static BybitApiClientFactory newInstance(String apiKey, String secret, String baseUrl) {
-        return new BybitApiClientFactory(apiKey, secret, baseUrl);
+        return new BybitApiClientFactory(apiKey, secret, baseUrl, false, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(String apiKey, String secret, long recvWindow) {
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, false, recvWindow, LogOption.SLF4J.getLogOptionType());
     }
 
     /**
@@ -102,7 +100,19 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory.
      */
     public static BybitApiClientFactory newInstance(String apiKey, String secret, boolean debugMode) {
-        return new BybitApiClientFactory(apiKey, secret, debugMode);
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, debugMode, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(String apiKey, String secret, boolean debugMode, String logOption) {
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, debugMode, DEFAULT_RECEIVING_WINDOW, logOption);
+    }
+
+    public static BybitApiClientFactory newInstance(String apiKey, String secret, boolean debugMode, long recvWindow) {
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, debugMode, recvWindow, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(String apiKey, String secret, boolean debugMode, long recvWindow, String logOption) {
+        return new BybitApiClientFactory(apiKey, secret, MAINNET_DOMAIN, debugMode, recvWindow, logOption);
     }
 
     /**
@@ -114,7 +124,11 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory
      */
     public static BybitApiClientFactory newInstance(String apiKey, String secret, String baseUrl, boolean debugMode) {
-        return new BybitApiClientFactory(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiClientFactory(apiKey, secret, baseUrl, debugMode, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(String apiKey, String secret, String baseUrl, long recvWindow) {
+        return new BybitApiClientFactory(apiKey, secret, baseUrl, false, recvWindow, LogOption.SLF4J.getLogOptionType());
     }
 
 
@@ -124,7 +138,11 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory
      */
     public static BybitApiClientFactory newInstance() {
-        return new BybitApiClientFactory(null, null);
+        return new BybitApiClientFactory(null, null, MAINNET_DOMAIN, false, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(long recvWindow) {
+        return new BybitApiClientFactory(null, null, MAINNET_DOMAIN, false, recvWindow, LogOption.SLF4J.getLogOptionType());
     }
 
     /**
@@ -134,7 +152,7 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory.
      */
     public static BybitApiClientFactory newInstance(String baseUrl) {
-        return new BybitApiClientFactory(null, null, baseUrl);
+        return new BybitApiClientFactory(null, null, baseUrl, false, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
     }
 
     /**
@@ -144,155 +162,183 @@ public class BybitApiClientFactory {
      * @return the Bybit api client factory.
      */
     public static BybitApiClientFactory newInstance(boolean debugMode) {
-        return new BybitApiClientFactory(null, null, debugMode);
+        return new BybitApiClientFactory(null, null, MAINNET_DOMAIN, debugMode, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
+    }
+
+    public static BybitApiClientFactory newInstance(boolean debugMode, String logOption) {
+        return new BybitApiClientFactory(null, null, MAINNET_DOMAIN, debugMode, DEFAULT_RECEIVING_WINDOW, logOption);
     }
 
     /**
      * New instance without authentication and with optional base url and debug mode
      *
-     * @param baseUrl base url
+     * @param baseUrl   base url
      * @param debugMode debug mode
      * @return the Bybit api client factory.
      */
+    public static BybitApiClientFactory newInstance(String baseUrl, boolean debugMode, String logOption) {
+        return new BybitApiClientFactory(null, null, baseUrl, debugMode, DEFAULT_RECEIVING_WINDOW, logOption);
+    }
+
     public static BybitApiClientFactory newInstance(String baseUrl, boolean debugMode) {
-        return new BybitApiClientFactory(null, null, baseUrl, debugMode);
+        return new BybitApiClientFactory(null, null, baseUrl, debugMode, DEFAULT_RECEIVING_WINDOW, LogOption.SLF4J.getLogOptionType());
     }
 
     /**
      * Creates a new synchronous/blocking REST client to spot leverage token and spot margin endpoints.
      */
     public BybitApiSpotMarginRestClient newSpotMarginRestClient() {
-        return new BybitApiSpotMarginRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiSpotMarginRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
 
     public BybitApiAsyncSpotMarginRestClient newSpotMarginAsyncRestClient() {
-        return new BybitApiAsyncSpotMarginRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncSpotMarginRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client.
      */
     public BybitApiUserRestClient newUserRestClient() {
-        return new BybitApiUserRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiUserRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking REST client to User and upgrade endpoints.
      */
     public BybitApiAsyncUserRestClient newAsyncUserRestClient() {
-        return new BybitApiAsyncUserRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncUserRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to Market Data Endpoints
      */
     public BybitApiMarketRestClient newMarketDataRestClient() {
-        return new BybitApiMarketRestClientImpl(baseUrl, debugMode);
+        return new BybitApiMarketRestClientImpl(baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking client to Market Data Endpoints
      */
     public BybitApiAsyncMarketDataRestClient newAsyncMarketDataRestClient() {
-        return new BybitApiMarketAsyncRestClientImpl(baseUrl, debugMode);
+        return new BybitApiMarketAsyncRestClientImpl(baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to Institution and Broker Endpoints
      */
     public BybitApiLendingRestClient newLendingRestClient() {
-        return new BybitApiLendingRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiLendingRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking REST client to Institution Lending Endpoints
      */
     public BybitApiAsyncLendingRestClient newAsyncLendingRestClient() {
-        return new BybitApiAsyncLendingRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncLendingRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to trading
      */
     public BybitApiTradeRestClient newTradeRestClient() {
-        return new BybitApiTradeRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiTradeRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking REST client to trading
      */
     public BybitApiAsyncTradeRestClient newAsyncTradeRestClient() {
-        return new BybitApiTradeAsyncRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiTradeAsyncRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to position data
      */
     public BybitApiPositionRestClient newPositionRestClient() {
-        return new BybitApiPositionRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiPositionRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking client to position data
      */
     public BybitApiAsyncPositionRestClient newAsyncPositionRestClient() {
-        return new BybitApiAsyncPositionRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncPositionRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to Account data
      */
     public BybitApiAccountRestClient newAccountRestClient() {
-        return new BybitApiAccountRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAccountRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking client to Account data
      */
     public BybitApiAsyncAccountRestClient newAsyncAccountRestClient() {
-        return new BybitApiAsyncAccountRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncAccountRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to Asset data
      */
     public BybitApiAssetRestClient newAssetRestClient() {
-        return new BybitApiAssetRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAssetRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking client to Asset data
      */
     public BybitApiAsyncAssetRestClient newAsyncAssetRestClient() {
-        return new BybitApiAsyncAssetRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncAssetRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new synchronous/blocking REST client to Broker earning data
      */
     public BybitApiBrokerRestClient newBrokerRestClient() {
-        return new BybitApBrokerRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApBrokerRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
      * Creates a new asynchronous/non-blocking client to Broker earning data
      */
     public BybitApiAsyncBrokerRestClient newAsyncBrokerRestClient() {
-        return new BybitApiAsyncBrokerRestClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new BybitApiAsyncBrokerRestClientImpl(apiKey, secret, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
-     * Access to public and private websocket without message handler
+     * Access to public websocket
      */
     public WebsocketClient newWebsocketClient() {
-        return new WebsocketClientImpl(apiKey, secret, baseUrl, debugMode);
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, DEFAULT_PING_INTERVAL, DEFAULT_MAX_ALIVE_TIME, debugMode, logOption, null);
     }
 
-    /**
-     * Access to public and private websocket with message handler
-     */
+    public WebsocketClient newWebsocketClient(int pingInterval) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, pingInterval, DEFAULT_MAX_ALIVE_TIME, debugMode, logOption, null);
+    }
+
+    public WebsocketClient newWebsocketClient(String maxAliveTime) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, DEFAULT_PING_INTERVAL, maxAliveTime, debugMode, logOption, null);
+    }
+
     public WebsocketClient newWebsocketClient(WebsocketMessageHandler messageHandler) {
-        return new WebsocketClientImpl(apiKey, secret, baseUrl, debugMode, messageHandler);
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, DEFAULT_PING_INTERVAL, DEFAULT_MAX_ALIVE_TIME, debugMode, logOption, messageHandler);
+    }
+
+    public WebsocketClient newWebsocketClient(int pingInterval, WebsocketMessageHandler messageHandler) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, pingInterval, DEFAULT_MAX_ALIVE_TIME, debugMode, logOption, messageHandler);
+    }
+    public WebsocketClient newWebsocketClient(int pingInterval, String maxAliveTime) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, pingInterval, maxAliveTime, debugMode, logOption, null);
+    }
+
+    public WebsocketClient newWebsocketClient(String maxAliveTime, WebsocketMessageHandler messageHandler) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, DEFAULT_PING_INTERVAL, maxAliveTime, debugMode, logOption, null);
+    }
+
+    public WebsocketClient newWebsocketClient(int pingInterval, String maxAliveTime, WebsocketMessageHandler messageHandler) {
+        return new WebsocketClientImpl(apiKey, secret, baseUrl, pingInterval, maxAliveTime, debugMode, logOption, messageHandler);
     }
 }

--- a/src/main/java/com/bybit/api/client/service/BybitApiServiceGenerator.java
+++ b/src/main/java/com/bybit/api/client/service/BybitApiServiceGenerator.java
@@ -53,8 +53,8 @@ public class BybitApiServiceGenerator {
             (Converter<ResponseBody, BybitApiError>) converterFactory.responseBodyConverter(
                     BybitApiError.class, new Annotation[0], null);
 
-    public static <S> S createService(Class<S> serviceClass, String baseUrl, boolean debugMode) {
-        return createService(serviceClass, null, null, baseUrl, debugMode);
+    public static <S> S createService(Class<S> serviceClass, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
+        return createService(serviceClass, null, null, baseUrl, debugMode, recvWindow, logOption);
     }
 
     /**
@@ -65,17 +65,17 @@ public class BybitApiServiceGenerator {
      * @param secret       Bybit secret.
      * @return a new implementation of the API endpoints for the Bybit API service.
      */
-    public static <S> S createService(Class<S> serviceClass, String apiKey, String secret, String baseUrl, boolean debugMode) {
+    public static <S> S createService(Class<S> serviceClass, String apiKey, String secret, String baseUrl, boolean debugMode, long recvWindow, String logOption) {
         Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
                 .baseUrl(baseUrl)
                 .addConverterFactory(converterFactory);
         OkHttpClient.Builder clientBuilder = sharedClient.newBuilder();
         if (!StringUtils.isEmpty(apiKey) && !StringUtils.isEmpty(secret)) {
-            AuthenticationInterceptor interceptor = new AuthenticationInterceptor(apiKey, secret);
+            AuthenticationInterceptor interceptor = new AuthenticationInterceptor(apiKey, secret, recvWindow);
             clientBuilder.addInterceptor(interceptor);
         }
         if (debugMode) {
-            HandleLoggingInterceptor(clientBuilder);
+            HandleLoggingInterceptor(clientBuilder, logOption);
         }
         retrofitBuilder.client(clientBuilder.build());
         Retrofit retrofit = retrofitBuilder.build();

--- a/src/main/java/com/bybit/api/client/service/BybitJsonConverter.java
+++ b/src/main/java/com/bybit/api/client/service/BybitJsonConverter.java
@@ -283,7 +283,7 @@ public class BybitJsonConverter {
                 .triggerPrice(tradeOrderRequest.getTriggerPrice()) // Optional
                 .triggerBy(tradeOrderRequest.getTriggerBy() == null ? null : tradeOrderRequest.getTriggerBy().getTrigger()) // Optional
                 .orderIv(tradeOrderRequest.getOrderIv())        // Optional
-                .timeInForce(tradeOrderRequest.getTimeInForce() == null ? null : tradeOrderRequest.getTimeInForce().getDescription()) // Optional and default value depends on order type
+                .timeInForce(tradeOrderRequest.getTimeInForce() == null ? null : tradeOrderRequest.getTimeInForce().getDescription()[0]) // Optional and default value depends on order type
                 .positionIdx(tradeOrderRequest.getPositionIdx() == null ? null : tradeOrderRequest.getPositionIdx().getIndex()) // Optional
                 .orderLinkId(tradeOrderRequest.getOrderLinkId()) // Optional
                 .takeProfit(tradeOrderRequest.getTakeProfit())  // Optional

--- a/src/main/java/com/bybit/api/client/service/TimeInForceSerializer.java
+++ b/src/main/java/com/bybit/api/client/service/TimeInForceSerializer.java
@@ -8,6 +8,6 @@ import java.io.IOException;
 public class TimeInForceSerializer extends JsonSerializer<TimeInForce> {
     @Override
     public void serialize(TimeInForce value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeString(value.getDescription());
+        gen.writeString(value.getDescription()[0]);
     }
 }

--- a/src/main/java/com/bybit/api/client/websocket/WebSocketHttpClientSingleton.java
+++ b/src/main/java/com/bybit/api/client/websocket/WebSocketHttpClientSingleton.java
@@ -10,26 +10,28 @@ import static com.bybit.api.client.log.Slf4jLoggingInterceptor.HandleLoggingInte
 @Getter
 public final class WebSocketHttpClientSingleton {
     private final boolean debugMode;
+    private final String logOption;
 
-    private WebSocketHttpClientSingleton(boolean debugMode) {
+    private WebSocketHttpClientSingleton(boolean debugMode, String logOption) {
         this.debugMode = debugMode;
+        this.logOption = logOption;
     }
 
-    public static WebSocketHttpClientSingleton createInstance(boolean debugMode) {
-        return new WebSocketHttpClientSingleton(debugMode);
+    public static WebSocketHttpClientSingleton createInstance(boolean debugMode, String logOption) {
+        return new WebSocketHttpClientSingleton(debugMode, logOption);
     }
 
-    public OkHttpClient createOkHttpClient(boolean debugMode) {
+    public OkHttpClient createOkHttpClient(boolean debugMode, String logOption) {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
         if (debugMode) {
-            HandleLoggingInterceptor(clientBuilder);
+            HandleLoggingInterceptor(clientBuilder, logOption);
         }
         return clientBuilder.build();
     }
 
     public void createWebSocket(String url, WebSocketListener listener) {
         Request request = new Request.Builder().url(url).build();
-        OkHttpClient okHttpClient = createOkHttpClient(debugMode);
+        OkHttpClient okHttpClient = createOkHttpClient(debugMode, logOption);
         okHttpClient.newWebSocket(request, listener);
     }
 }

--- a/src/test/java/com/bybit/api/domain/market/OpenInterestResultDeserializerTest.java
+++ b/src/test/java/com/bybit/api/domain/market/OpenInterestResultDeserializerTest.java
@@ -4,8 +4,6 @@ import com.bybit.api.client.domain.CategoryType;
 import com.bybit.api.client.domain.GenericResponse;
 import com.bybit.api.client.domain.market.response.openInterests.OpenInterestEntry;
 import com.bybit.api.client.domain.market.response.openInterests.OpenInterestResult;
-import com.bybit.api.client.domain.market.response.tickers.TickerEntry;
-import com.bybit.api.client.domain.market.response.tickers.TickersResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;

--- a/src/test/java/com/bybit/api/domain/market/RecentTradeResultDeserializerTest.java
+++ b/src/test/java/com/bybit/api/domain/market/RecentTradeResultDeserializerTest.java
@@ -4,8 +4,6 @@ import com.bybit.api.client.domain.CategoryType;
 import com.bybit.api.client.domain.GenericResponse;
 import com.bybit.api.client.domain.market.response.recentTrade.RecentTradeEntry;
 import com.bybit.api.client.domain.market.response.recentTrade.RecentTradeResult;
-import com.bybit.api.client.domain.market.response.tickers.TickerEntry;
-import com.bybit.api.client.domain.market.response.tickers.TickersResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -21,64 +19,64 @@ public class RecentTradeResultDeserializerTest {
     public void testRecentTradeResultDeserializer()
     {
         final String tradesResultJson = "{\n" +
-                "    \"retCode\": 0,\n" +
-                "    \"retMsg\": \"OK\",\n" +
-                "    \"result\": {\n" +
-                "        \"category\": \"spot\",\n" +
-                "        \"list\": [\n" +
-                "            {\n" +
-                "                \"execId\": \"2110000000029412877\",\n" +
-                "                \"symbol\": \"SOLUSDT\",\n" +
-                "                \"price\": \"59.6001\",\n" +
-                "                \"size\": \"0.85\",\n" +
-                "                \"side\": \"Sell\",\n" +
-                "                \"time\": \"1699782067852\",\n" +
-                "                \"isBlockTrade\": false\n" +
-                "            },\n" +
-                "            {\n" +
-                "                \"execId\": \"2110000000029412870\",\n" +
-                "                \"symbol\": \"SOLUSDT\",\n" +
-                "                \"price\": \"59.6216\",\n" +
-                "                \"size\": \"0.57\",\n" +
-                "                \"side\": \"Sell\",\n" +
-                "                \"time\": \"1699782050312\",\n" +
-                "                \"isBlockTrade\": false\n" +
-                "            },\n" +
-                "            {\n" +
-                "                \"execId\": \"2110000000029412865\",\n" +
-                "                \"symbol\": \"SOLUSDT\",\n" +
-                "                \"price\": \"59.5813\",\n" +
-                "                \"size\": \"0.3\",\n" +
-                "                \"side\": \"Sell\",\n" +
-                "                \"time\": \"1699782035987\",\n" +
-                "                \"isBlockTrade\": false\n" +
-                "            },\n" +
-                "            {\n" +
-                "                \"execId\": \"2110000000029412864\",\n" +
-                "                \"symbol\": \"SOLUSDT\",\n" +
-                "                \"price\": \"61.75\",\n" +
-                "                \"size\": \"0.43\",\n" +
-                "                \"side\": \"Sell\",\n" +
-                "                \"time\": \"1699782035987\",\n" +
-                "                \"isBlockTrade\": false\n" +
-                "            },\n" +
-                "            {\n" +
-                "                \"execId\": \"2110000000029412861\",\n" +
-                "                \"symbol\": \"SOLUSDT\",\n" +
-                "                \"price\": \"61.75\",\n" +
-                "                \"size\": \"0.61\",\n" +
-                "                \"side\": \"Sell\",\n" +
-                "                \"time\": \"1699782025973\",\n" +
-                "                \"isBlockTrade\": false\n" +
-                "            }\n" +
-                "        ]\n" +
-                "    },\n" +
-                "    \"retExtInfo\": {},\n" +
-                "    \"time\": 1699817872798\n" +
-                "}";
+                                        "    \"retCode\": 0,\n" +
+                                        "    \"retMsg\": \"OK\",\n" +
+                                        "    \"result\": {\n" +
+                                        "        \"category\": \"spot\",\n" +
+                                        "        \"list\": [\n" +
+                                        "            {\n" +
+                                        "                \"execId\": \"2110000000029412877\",\n" +
+                                        "                \"symbol\": \"SOLUSDT\",\n" +
+                                        "                \"price\": \"59.6001\",\n" +
+                                        "                \"size\": \"0.85\",\n" +
+                                        "                \"side\": \"Sell\",\n" +
+                                        "                \"time\": \"1699782067852\",\n" +
+                                        "                \"isBlockTrade\": false\n" +
+                                        "            },\n" +
+                                        "            {\n" +
+                                        "                \"execId\": \"2110000000029412870\",\n" +
+                                        "                \"symbol\": \"SOLUSDT\",\n" +
+                                        "                \"price\": \"59.6216\",\n" +
+                                        "                \"size\": \"0.57\",\n" +
+                                        "                \"side\": \"Sell\",\n" +
+                                        "                \"time\": \"1699782050312\",\n" +
+                                        "                \"isBlockTrade\": false\n" +
+                                        "            },\n" +
+                                        "            {\n" +
+                                        "                \"execId\": \"2110000000029412865\",\n" +
+                                        "                \"symbol\": \"SOLUSDT\",\n" +
+                                        "                \"price\": \"59.5813\",\n" +
+                                        "                \"size\": \"0.3\",\n" +
+                                        "                \"side\": \"Sell\",\n" +
+                                        "                \"time\": \"1699782035987\",\n" +
+                                        "                \"isBlockTrade\": false\n" +
+                                        "            },\n" +
+                                        "            {\n" +
+                                        "                \"execId\": \"2110000000029412864\",\n" +
+                                        "                \"symbol\": \"SOLUSDT\",\n" +
+                                        "                \"price\": \"61.75\",\n" +
+                                        "                \"size\": \"0.43\",\n" +
+                                        "                \"side\": \"Sell\",\n" +
+                                        "                \"time\": \"1699782035987\",\n" +
+                                        "                \"isBlockTrade\": false\n" +
+                                        "            },\n" +
+                                        "            {\n" +
+                                        "                \"execId\": \"2110000000029412861\",\n" +
+                                        "                \"symbol\": \"SOLUSDT\",\n" +
+                                        "                \"price\": \"61.75\",\n" +
+                                        "                \"size\": \"0.61\",\n" +
+                                        "                \"side\": \"Sell\",\n" +
+                                        "                \"time\": \"1699782025973\",\n" +
+                                        "                \"isBlockTrade\": false\n" +
+                                        "            }\n" +
+                                        "        ]\n" +
+                                        "    },\n" +
+                                        "    \"retExtInfo\": {},\n" +
+                                        "    \"time\": 1699817872798\n" +
+                                        "}";
         ObjectMapper mapper = new ObjectMapper();
         try {
-            GenericResponse<RecentTradeResult> response = mapper.readValue(tradesResultJson, new TypeReference<GenericResponse<RecentTradeResult>>() {
+            GenericResponse<RecentTradeResult> response = mapper.readValue(tradesResultJson, new TypeReference<>() {
             });
             // You can now access the fields of the response
             assertEquals(response.getRetCode(), 0);

--- a/src/test/java/com/bybit/api/domain/market/TickersResultDeserializerTest.java
+++ b/src/test/java/com/bybit/api/domain/market/TickersResultDeserializerTest.java
@@ -2,8 +2,6 @@ package com.bybit.api.domain.market;
 
 import com.bybit.api.client.domain.CategoryType;
 import com.bybit.api.client.domain.GenericResponse;
-import com.bybit.api.client.domain.market.response.orderbook.OrderbookBidEntry;
-import com.bybit.api.client.domain.market.response.orderbook.OrderbookResult;
 import com.bybit.api.client.domain.market.response.tickers.TickerEntry;
 import com.bybit.api.client.domain.market.response.tickers.TickersResult;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/src/test/java/com/bybit/api/examples/Websocket/WebsocketDebuggerExample.java
+++ b/src/test/java/com/bybit/api/examples/Websocket/WebsocketDebuggerExample.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class WebsocketDebuggerExample {
     public static void main(String[] args) {
-        var client = BybitApiClientFactory.newInstance(BybitApiConfig.STREAM_TESTNET_DOMAIN, true).newWebsocketClient();
+        var client = BybitApiClientFactory.newInstance(BybitApiConfig.STREAM_TESTNET_DOMAIN, true, "okhttp3").newWebsocketClient(20);
 
         // Orderbook
         client.getPublicChannelStream(List.of("orderbook.50.MATICUSDT"), BybitApiConfig.V5_PUBLIC_LINEAR);

--- a/src/test/java/com/bybit/api/examples/Websocket/WebsocketPrivateChannelExamples.java
+++ b/src/test/java/com/bybit/api/examples/Websocket/WebsocketPrivateChannelExamples.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class WebsocketPrivateChannelExamples {
     public static void main(String[] args) {
-        var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
+        var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
         // Position
         // client.getOrderBookStream(List.of("position.linear"), BybitApiConfig.V5_PRIVATE);
 

--- a/src/test/java/com/bybit/api/examples/Websocket/WebsocketPrivateChannelExamples.java
+++ b/src/test/java/com/bybit/api/examples/Websocket/WebsocketPrivateChannelExamples.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class WebsocketPrivateChannelExamples {
     public static void main(String[] args) {
-        var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient((message) -> System.out.println("Handle message :" + message));
+        var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.STREAM_TESTNET_DOMAIN).newWebsocketClient(5, "60s", (message) -> System.out.println("Handle message :" + message));
         // Position
         // client.getOrderBookStream(List.of("position.linear"), BybitApiConfig.V5_PRIVATE);
 

--- a/src/test/java/com/bybit/api/examples/http/sync/BatchOrdersExample.java
+++ b/src/test/java/com/bybit/api/examples/http/sync/BatchOrdersExample.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 public class BatchOrdersExample {
     public static void main(String[] args) throws IOException {
-        var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.TESTNET_DOMAIN).newTradeRestClient();
+        var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newTradeRestClient();
 
         // Create a batch order
         var orderRequests = Arrays.asList(TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")

--- a/src/test/java/com/bybit/api/examples/http/sync/BatchOrdersExample.java
+++ b/src/test/java/com/bybit/api/examples/http/sync/BatchOrdersExample.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 public class BatchOrdersExample {
     public static void main(String[] args) throws IOException {
-        var client = BybitApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_API_SECRET", BybitApiConfig.TESTNET_DOMAIN).newTradeRestClient();
+        var client = BybitApiClientFactory.newInstance("8wYkmpLsMg10eNQyPm", "Ouxc34myDnXvei54XsBZgoQzfGxO4bkr2Zsj", BybitApiConfig.TESTNET_DOMAIN).newTradeRestClient();
 
         // Create a batch order
         var orderRequests = Arrays.asList(TradeOrderRequest.builder().category(CategoryType.OPTION).symbol("BTC-10FEB23-24000-C").side(Side.BUY).orderType(TradeOrderType.LIMIT).qty("0.1")

--- a/src/test/java/com/bybit/api/log/Slf4jLoggingTest.java
+++ b/src/test/java/com/bybit/api/log/Slf4jLoggingTest.java
@@ -34,8 +34,7 @@ public class Slf4jLoggingTest {
     @Test
     public void testInterceptorLogsHeaders() {
         // Trigger the logging
-        BybitApiConfig.useSlf4j = true;
-        BybitApiClientFactory.newInstance(BybitApiConfig.TESTNET_DOMAIN, true)
+        BybitApiClientFactory.newInstance(BybitApiConfig.TESTNET_DOMAIN, true, "slf4j")
                 .newMarketDataRestClient().getServerTime();
 
         // Get captured log events


### PR DESCRIPTION
### HTTP Sync & Async Request
- Receive Window Parameter: Added by default (5 seconds).
- Debug Mode Parameter: Added by default (false) to print request and response headers.
- Base URL Setting: Allows setting to testnet or mainnet.
- Log Option Interceptor Parameter: Currently supports SLF4J and OkHttp3; planning to support customized messaging in the next version.
- Trade API: For create/amend/cancel single & batch orders, now supports dedicated class, map, and JSON.
- Asset API: Deposit and withdrawal operations will automatically generate a transfer ID.

### WebSocket
- Ping Pong Interval Parameter: Added by default (20 seconds).
- Max Alive Time Parameter: Only supports private channel, ranging from 30s to 600s (also supports minutes).
- Log Option Interceptor for WebSocket: Currently supports SLF4J and OkHttp3; planning to support customized messaging in the next version.

### Improvements
- Class Mapping for POST Requests: Each POST request will have a class mapped and converted to JSON for the request body.
- Enhanced Unit Tests: Added more tests for serialization and deserialization of data.
- Performance Tests for WebSocket: Added tests for maximum argument limits.
- POST Request Handling: Parameters not supported in query string will be reset to the body.
- Security Enhancements: Secure check for signed requests implemented.
### Change Log
- CategoryType: Renamed from ProductType.
- Deprecated useTestnet: This function is now deprecated.
- Serialization Optimization: No reserialization of data before sending POST requests, using conversion instead.
